### PR TITLE
fix: ensure portability of `tr`

### DIFF
--- a/install-template.sh
+++ b/install-template.sh
@@ -11,7 +11,7 @@ fi
 echo "Installing toolchain $HERMIT_TOOLCHAIN with rustup."
 rustup toolchain install $HERMIT_TOOLCHAIN
 
-RUSTC_SYSROOT="$(rustc +$HERMIT_TOOLCHAIN --print=sysroot | tr '\' '/')"
+RUSTC_SYSROOT="$(rustc +$HERMIT_TOOLCHAIN --print=sysroot | tr '\\' '/')"
 SCRIPT_DIR="${0%/*}"
 echo "Installing rust-std-hermit to $RUSTC_SYSROOT"
 "$SCRIPT_DIR/rust-install.sh" --prefix="$RUSTC_SYSROOT" --disable-ldconfig


### PR DESCRIPTION
Without this fix the execution of `tr` on a linux system would not work as expected.

The following warning was shown at runtime:

```
tr: warning: an unescaped backslash at end of string is not portable
```
